### PR TITLE
Several build updates, plus a Scala 2.11.0-RC1 build.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import CrossVersion.partialVersion
+
 name := "f0"
 
 organization := "com.clarifi"
@@ -6,20 +8,25 @@ description := "Multi-language serialization protocol."
 
 version := "1.1"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.3"
 
-crossScalaVersions := Seq("2.9.2", "2.10.1", "2.10.2")
+crossScalaVersions := Seq("2.9.2", "2.9.3", "2.10.3", "2.11.0-RC1")
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
-scalacOptions <++= scalaVersion map {
-  case sv if sv.contains("2.10") =>
-    Seq("-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps")
-  case _ =>
-    Seq("-Ydependent-method-types")
+scalacOptions ++= {
+  val non29 = Seq("-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps")
+  partialVersion(scalaVersion.value) match {
+    case Some((2, 9)) => Seq("-Ydependent-method-types")
+    case Some((2, 10)) => non29
+    case sv => non29 ++ Seq("-Ywarn-unused-import")
+  }
 }
 
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.0" % "test"
+libraryDependencies += {
+  val scalacheck = if (scalaVersion.value == "2.9.2") "1.10.1" else "1.11.3"
+  "org.scalacheck" %% "scalacheck" % scalacheck % "test"
+}
 
 seq(bintraySettings:_*)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0-RC4
+sbt.version=0.13.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.0")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")

--- a/src/test/scala/f0/F0Spec.scala
+++ b/src/test/scala/f0/F0Spec.scala
@@ -12,7 +12,7 @@ object F0Spec extends Properties("F0") {
   implicit val stringArb = Arbitrary(Gen.alphaStr)
   def clone[A:Arbitrary,F](w: Writer[A,F], r: Reader[A,F]): Prop =
     forAll((a: A) => {
-      (r(w.toByteArray(a)) ?= a)
+      ?=(r(w.toByteArray(a)), a)
     })
 
   property("int") = clone(intW, intR)


### PR DESCRIPTION
- Add a 2.11.0-RC1 build; its only difference from other versions is that unused imports are warned about.
- Only one 2.10.x cross-build is needed; remove redundant one.
- Build standard against 2.10.3.
- Update scalacheck as far as possible for each supported scala version.
- Infix ?= is wonky for scala 2.9.2+scalacheck 1.10.1; use function version instead.  It becomes easy to use ?= again once 2.9.2 support is dropped.
- Update sbt to 0.13.1.
- Update bintray-sbt to 0.1.1.
- Add a 2.9.3 build, too.  Perhaps this can replace the 2.9.2 build entirely.
